### PR TITLE
Add passenger in drive view

### DIFF
--- a/frontend/ClickAndDrive/src/app/layout/drive-in-progress/drive-in-progress.css
+++ b/frontend/ClickAndDrive/src/app/layout/drive-in-progress/drive-in-progress.css
@@ -95,3 +95,37 @@
 .origin, .destination, .time {
   color: #F5CB5C;
 }
+.report, .rate {
+  height: 45px;
+  outline: none;
+  border: none;
+  border-radius: 100px;
+  font-size: 17px;
+  cursor: pointer;
+  transition: .3s;
+  font-weight: bold;
+}
+
+/* REPORT button */
+.report {
+  width: 200px; 
+  background-color: #F55C5C; 
+  color: white;
+  text-transform: uppercase;
+}
+
+.report:hover {
+  background-color: #f55c5cd0;
+  transform: scale(1.02);
+}
+
+/* RATE button - maybe not necessary */
+.rate {
+  width: 200px;
+  background-color: #F5CB5C;
+  color: #242423;
+}
+
+.rate:hover {
+  background-color: #f5cc5ccf;
+}

--- a/frontend/ClickAndDrive/src/app/layout/drive-in-progress/drive-in-progress.html
+++ b/frontend/ClickAndDrive/src/app/layout/drive-in-progress/drive-in-progress.html
@@ -1,4 +1,5 @@
 <app-map-view size="small">
+    <!-- Podaci o vožnji (Origin/Destination) -->
     <div class="ride-data">
         <p>Origin: <span class="origin">Bulevar oslobodjenja 45</span></p>
         <p>Destination: <span class="destination">Cara Dušana 12</span></p>
@@ -8,6 +9,19 @@
 </app-map-view>
 
 <div class="buttons">
-    <button class="stop">Stop drive</button>
-    <button class="finish">Finish drive</button>
+    <!--  DRIVER  -->
+    @if (auth.userType() === 'driver') {
+        <button class="stop">Stop drive</button>
+        <button class="finish">Finish drive</button>
+    }
+
+    <!--  PASSENGER  -->
+    @if (auth.userType() === 'user') {
+        @if (auth.inDrive()) {
+            <button class="report" (click)="onReport()">REPORT</button>
+        } @else {
+            <!-- Button for rating after the ride (Point 2.8) -->
+            <button class="finish" style="width: 300px" (click)="onRate()">RATE RIDE</button>
+        }
+    }
 </div>

--- a/frontend/ClickAndDrive/src/app/layout/drive-in-progress/drive-in-progress.ts
+++ b/frontend/ClickAndDrive/src/app/layout/drive-in-progress/drive-in-progress.ts
@@ -1,13 +1,49 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MapViewComponent } from '../../components/map-view/map-view';
-import { RouterOutlet } from '@angular/router';
+import { RouterOutlet, Router } from '@angular/router';
+import { AuthService } from '../../services/auth.service'; // Putanja do tvog servisa
 
 @Component({
   selector: 'app-drive-in-progress',
+  standalone: true, // Ako koristite standalone
   imports: [RouterOutlet, MapViewComponent],
   templateUrl: './drive-in-progress.html',
   styleUrl: './drive-in-progress.css',
 })
 export class DriveInProgress {
+  auth = inject(AuthService);
+  router = inject(Router);
 
+  // Your methods (Student 2)
+  onPanic() {
+    console.log("Panic triggered!");
+    // Logic for PANIC (2.6.3)
+  }
+
+  onReportInconsistency() {
+    const reason = prompt("Enter inconsistency reason:");
+    console.log("Reported:", reason);
+    
+  }
+
+  // Funkcija za Report dugme (MORA SE ZVATI onReport jer je tako u HTML-u)
+  onReport() {
+    const reason = prompt("Why is the route inconsistent?");
+    if (reason) {
+      console.log("Reported reason:", reason);
+      alert("Inconsistency reported.");
+    }
+  }
+
+  // Funkcija za Rate dugme (MORA SE ZVATI onRate jer je tako u HTML-u)
+  onRate() {
+    console.log("Navigating to rating screen...");
+    //this.router.navigate(['/rating']); // Otkomentariši kada napraviš rutu za ocenjivanje
+    alert("Redirecting to rating page...");
+  }
+
+  
+  goToRating() {
+    this.router.navigate(['/rate-ride']);
+  }
 }

--- a/frontend/ClickAndDrive/src/app/layout/ride-ordering/ride-ordering.ts
+++ b/frontend/ClickAndDrive/src/app/layout/ride-ordering/ride-ordering.ts
@@ -1,5 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { AuthService } from '../../services/auth.service'; 
 
 @Component({
   selector: 'app-ride-ordering',
@@ -8,6 +10,10 @@ import { FormsModule } from '@angular/forms';
   styleUrl: './ride-ordering.css',
 })
 export class RideOrdering {
+  //services
+  private authService = inject(AuthService);
+  private router = inject(Router);
+
   // These are static fields, we have one value and one input
   topFields = [
     {label: 'origin', text: 'Origin:', type: 'text', placeholder: 'Zabalj', required: true},
@@ -17,8 +23,8 @@ export class RideOrdering {
   bottomFields = [
     {label: 'type', text: 'Vehicle type:', type: 'select', options: ['Luxury', 'Standard', 'Van'], required: true},
     {label: 'time', text: 'Set time:', type: 'time', placeholder: '', required: true},
-    {label: 'baby-friendly', text: 'Baby friendly:', type: 'checkbox', placeholder: '', required: true},
-    {label: 'pet-friendly', text: 'Pet friendly:', type: 'checkbox', placeholder: '', required: true}
+    {label: 'baby-friendly', text: 'Baby friendly:', type: 'checkbox', placeholder: '', required: false},
+    {label: 'pet-friendly', text: 'Pet friendly:', type: 'checkbox', placeholder: '', required: false}
   ]
 
   showStopsModal = false;
@@ -71,31 +77,45 @@ export class RideOrdering {
   }  
 
   onFinishOrder() {
-    this.invalidFields = []; // empty the list
+  this.invalidFields = []; 
 
-    // Check every field
-    this.allFields.forEach(field => {
-      if (field.required) {
-        const element = document.getElementById(field.label) as HTMLInputElement | HTMLSelectElement;
+  // Validation logic
+  this.allFields.forEach(field => {
+    if (field.required) {
+      const element = document.getElementById(field.label) as HTMLInputElement | HTMLSelectElement;
 
-        if (field.type === 'checkbox') {
-          const checkbox = element as HTMLInputElement;
-          if (!checkbox.checked) {
-            this.invalidFields.push(field.label);
-          }
-        } else {
-          if (!element.value || element.value.trim() === '') {
-            this.invalidFields.push(field.label);
-          }
+      if (field.type === 'checkbox') {
+        const checkbox = element as HTMLInputElement;
+        if (!checkbox.checked) {
+          this.invalidFields.push(field.label);
+        }
+      } else {
+        if (!element || !element.value || element.value.trim() === '') {
+          this.invalidFields.push(field.label);
         }
       }
-    });
-    // .....
+    }
+  });
 
-    // clean dynamic values
-    this.additionalStops.filter(s => s.trim() !== '');
-    this.linkedPassengers.filter(p => p.trim() !== '');
+  // If there are invalid fields, stop the method here (do not navigate)
+  if (this.invalidFields.length > 0) {
+    console.log("Validation failed for fields:", this.invalidFields);
+    return; 
   }
+
+  // If validation passed (invalidFields is empty), continue:
+  console.log("Validation passed! Ordering ride...");
+
+  // Clear empty entries from dynamic fields (additional stops and passengers)
+  this.additionalStops = this.additionalStops.filter(s => s.trim() !== '');
+  this.linkedPassengers = this.linkedPassengers.filter(p => p.trim() !== '');
+
+  // Activating the driving state in the service
+  this.authService.setInDrive(true);
+
+  // Navigating to the drive-in-progress page
+  this.router.navigate(['/drive-in-progress']);
+}
 
   isFieldInvalid(label: string): boolean {
     return this.invalidFields.includes(label);


### PR DESCRIPTION
Introduces 'REPORT' and 'RATE RIDE' buttons for passengers in the drive-in-progress view, with corresponding styling and logic. Updates ride-ordering validation to allow optional baby/pet-friendly fields, and sets driving state and navigation after successful order. Improves separation of driver and passenger actions in the UI.

Closses #27 

Important for https://trello.com/c/yu7mfj1m/49-s2262-ride-tracking-driver-inconsistency-report-8