### PR TITLE
Add vehicle price management and admin popup

### DIFF
--- a/backend/src/main/java/com/example/demo/controller/AdminController.java
+++ b/backend/src/main/java/com/example/demo/controller/AdminController.java
@@ -6,10 +6,9 @@ import com.example.demo.dto.request.DriverRegistrationRequestDTO;
 import com.example.demo.dto.response.*;
 import com.example.demo.dto.VehiclePriceDTO;
 
-import com.example.demo.services.interfaces.DriverService;
-import com.example.demo.services.interfaces.PanicService;
-import com.example.demo.services.interfaces.PassengerService;
-import com.example.demo.services.interfaces.UserService;
+import com.example.demo.model.VehiclePrice;
+import com.example.demo.repositories.VehiclePriceRepository;
+import com.example.demo.services.interfaces.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -32,6 +31,8 @@ public class AdminController {
     private final PassengerService passengerService;
     private final UserService userService;
     private final PanicService panicService;
+    private final VehiclePriceRepository priceRepository;
+    private final VehiclePriceService priceService;
 
     @PostMapping("/drivers")
     public ResponseEntity<DriverRegistrationResponseDTO> registerDriver(
@@ -76,15 +77,14 @@ public class AdminController {
     // 2.14: GET prices
     @GetMapping("/prices")
     public ResponseEntity<VehiclePriceDTO> getVehiclePrices() {
-        return ResponseEntity.ok(new VehiclePriceDTO(200.0, 500.0, 300.0, 120.0));
+        return ResponseEntity.ok(priceService.getPrices());
     }
 
     // 2.14: UPDATE prices
     @PutMapping("/prices")
     public ResponseEntity<VehiclePriceDTO> updateVehiclePrices(@RequestBody VehiclePriceDTO request) {
-        return ResponseEntity.ok(new VehiclePriceDTO(
-                request.getStandardBasePrice(), request.getLuxuryBasePrice(),
-                request.getVanBasePrice(), request.getPricePerKm()));
+        VehiclePriceDTO updated = priceService.updatePrices(request);
+        return ResponseEntity.ok(updated);
     }
 
     // GET all drivers

--- a/backend/src/main/java/com/example/demo/repositories/RideRepository.java
+++ b/backend/src/main/java/com/example/demo/repositories/RideRepository.java
@@ -20,4 +20,6 @@ public interface RideRepository extends JpaRepository<Ride, Long> {
 
     @Query("SELECT r FROM Ride r JOIN r.passengers p WHERE p.id = :passengerId")
     List<Ride> findAllByPassengerId(@Param("passengerId") Long passengerId);
+
+    List<Ride> findAllByStatus(RideStatus rideStatus);
 }

--- a/backend/src/main/java/com/example/demo/services/VehiclePriceServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/services/VehiclePriceServiceImpl.java
@@ -1,0 +1,39 @@
+package com.example.demo.services;
+import com.example.demo.dto.VehiclePriceDTO;
+import com.example.demo.model.VehiclePrice;
+import com.example.demo.repositories.VehiclePriceRepository;
+import com.example.demo.services.interfaces.VehiclePriceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class VehiclePriceServiceImpl implements VehiclePriceService {
+    private final VehiclePriceRepository vehiclePriceRepository;
+
+    public VehiclePriceDTO getPrices() {
+        // Always ID 1 only
+        VehiclePrice prices = vehiclePriceRepository.findById(1L)
+                .orElseGet(() -> vehiclePriceRepository.save(new VehiclePrice(1L, 150.0, 500.0, 250.0, 120.0)));
+
+        return new VehiclePriceDTO(
+                prices.getStandard(),
+                prices.getLuxury(),
+                prices.getVan(),
+                prices.getPerKm()
+        );
+    }
+
+    public VehiclePriceDTO updatePrices(VehiclePriceDTO dto) {
+        VehiclePrice prices = new VehiclePrice(
+                1L,
+                dto.getStandardBasePrice(),
+                dto.getLuxuryBasePrice(),
+                dto.getVanBasePrice(),
+                dto.getPricePerKm()
+        );
+        vehiclePriceRepository.save(prices);
+        return dto;
+    }
+
+}

--- a/backend/src/main/java/com/example/demo/services/interfaces/VehiclePriceService.java
+++ b/backend/src/main/java/com/example/demo/services/interfaces/VehiclePriceService.java
@@ -1,0 +1,9 @@
+package com.example.demo.services.interfaces;
+
+import com.example.demo.dto.VehiclePriceDTO;
+
+public interface VehiclePriceService {
+    public VehiclePriceDTO getPrices();
+    public VehiclePriceDTO updatePrices(VehiclePriceDTO dto);
+
+}

--- a/frontend/ClickAndDrive/src/app/change-price-popup/change-price-popup.css
+++ b/frontend/ClickAndDrive/src/app/change-price-popup/change-price-popup.css
@@ -1,0 +1,59 @@
+.popup-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(4px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+}
+
+.price-popup {
+  background: #242423;
+  width: 300px;
+  padding: 30px;
+  border-radius: 15px;
+  border: 1px solid #F5CB5C;
+  color: white;
+}
+
+.title {
+  text-align: center;
+  font-size: 24px;
+  font-style: italic;
+  color: #F5CB5C;
+  margin-bottom: 30px;
+}
+
+.input-group {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.input-group label {
+  font-size: 18px;
+}
+
+.input-group input {
+  width: 120px;
+  background: #A7A7A7;
+  border: none;
+  padding: 5px;
+  border-radius: 5px;
+  text-align: center;
+  font-weight: bold;
+}
+
+.save-btn {
+  width: 100%;
+  padding: 12px;
+  background: #F5CB5C;
+  border-radius: 30px;
+  border: none;
+  font-weight: bold;
+  cursor: pointer;
+  margin-top: 20px;
+}

--- a/frontend/ClickAndDrive/src/app/change-price-popup/change-price-popup.html
+++ b/frontend/ClickAndDrive/src/app/change-price-popup/change-price-popup.html
@@ -1,0 +1,32 @@
+<div class="popup-overlay" (click)="popupService.close()">
+  <div class="price-popup" (click)="$event.stopPropagation()">
+    <p class="title">Change prices</p>
+
+    @if (prices.standardBasePrice !== 0) {
+    <div class="input-group">
+        <label>Standard:</label>
+        <input type="number" [(ngModel)]="prices.standardBasePrice">
+    </div>
+    <div class="input-group">
+      <label>Luxury:</label>
+      <input type="number" [(ngModel)]="prices.luxuryBasePrice">
+    </div>
+
+    <div class="input-group">
+      <label>Van:</label>
+      <input type="number" [(ngModel)]="prices.vanBasePrice">
+    </div>
+
+    <div class="input-group">
+      <label>Price per km:</label>
+      <input type="number" [(ngModel)]="prices.pricePerKm">
+    </div>
+
+    <button class="save-btn" (click)="save()">Update prices</button>
+    }@else {
+      <p style="text-align: center;">Loading prices...</p>
+    }
+
+    
+  </div>
+</div>

--- a/frontend/ClickAndDrive/src/app/change-price-popup/change-price-popup.spec.ts
+++ b/frontend/ClickAndDrive/src/app/change-price-popup/change-price-popup.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChangePricePopup } from './change-price-popup';
+
+describe('ChangePricePopup', () => {
+  let component: ChangePricePopup;
+  let fixture: ComponentFixture<ChangePricePopup>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChangePricePopup]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ChangePricePopup);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/ClickAndDrive/src/app/change-price-popup/change-price-popup.ts
+++ b/frontend/ClickAndDrive/src/app/change-price-popup/change-price-popup.ts
@@ -1,0 +1,53 @@
+import { Component, OnInit, ChangeDetectorRef} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { AdminService } from '../services/admin.service';
+import { AdminPopupService } from '../services/admin-popup.service';
+import { VehiclePrice } from '../services/models/vehicle-price';
+import { ToastrService } from 'ngx-toastr';
+
+@Component({
+  selector: 'app-change-price-popup',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './change-price-popup.html',
+  styleUrls: ['./change-price-popup.css']
+})
+export class ChangePricePopup implements OnInit {
+  prices: VehiclePrice = {
+    standardBasePrice: 0,
+    luxuryBasePrice: 0,
+    vanBasePrice: 0,
+    pricePerKm: 0
+  };
+
+  constructor(
+    private adminService: AdminService, 
+    public popupService: AdminPopupService,
+    public toastr: ToastrService,
+    private cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit() {
+    this.adminService.getPrices().subscribe({
+      next: (res) => {
+        this.prices = res;
+        this.cdr.detectChanges(); // Force update to reflect new prices in the form
+      },
+      error: (err) => console.error("Greška pri ucitavanju cena:", err)
+    });
+  }
+
+  save() {
+    this.adminService.updatePrices(this.prices).subscribe({
+      next: () => {
+        this.toastr.success("Prices updated successfully!");
+        this.popupService.close();
+      },
+      error: (err) => {
+        this.toastr.error("Failed to update prices.");
+        console.error("Error updating prices:", err);
+      }
+    });
+  }
+}

--- a/frontend/ClickAndDrive/src/app/layout/admin-profile/admin-profile.ts
+++ b/frontend/ClickAndDrive/src/app/layout/admin-profile/admin-profile.ts
@@ -5,6 +5,7 @@ import { UserService } from '../../services/user.service';
 import { UserProfileInformation } from '../../services/models/user-profile-information';
 import { CommonModule } from '@angular/common';
 import { ToastrService } from 'ngx-toastr';
+import { AdminPopupService } from '../../services/admin-popup.service';
 
 @Component({
   selector: 'app-admin-profile',
@@ -42,6 +43,7 @@ export class AdminProfile {
     private router: Router,
     private authService: AuthService,
     private userService: UserService,
+    private adminPopupService: AdminPopupService,
     private cdr: ChangeDetectorRef,
     private toastr: ToastrService
   ) {}
@@ -89,6 +91,11 @@ export class AdminProfile {
     if (button.logout) {
       this.authService.logout();
       return;
+    }
+
+    if (button.label === 'Change prices') { // DODAJ OVU LOGIKU
+        this.adminPopupService.open();
+        return;
     }
 
     if (button.route) {

--- a/frontend/ClickAndDrive/src/app/main-page/main-page.html
+++ b/frontend/ClickAndDrive/src/app/main-page/main-page.html
@@ -9,7 +9,7 @@
 
 <router-outlet></router-outlet>
 
-<div class="overlay" [class.open]="ridePopup.isOpen()" (click)="onOverlayClick()"></div>
+<div class="overlay" [class.open]="ridePopup.isOpen() || adminPopup.isOpen()" (click)="onOverlayClick()"></div>
 
 <!-- POPUP -->
 @if (ridePopup.isOpen()) {
@@ -47,4 +47,9 @@
     </app-ride-ordering>
   </div>
   }
+}
+
+<!-- ADMIN change prices popup -->
+@if (adminPopup.isOpen()) {
+    <app-change-price-popup></app-change-price-popup>
 }

--- a/frontend/ClickAndDrive/src/app/main-page/main-page.ts
+++ b/frontend/ClickAndDrive/src/app/main-page/main-page.ts
@@ -9,17 +9,24 @@ import { Location } from '../services/models/location';
 import { SharedRideDataService } from '../services/shared-ride-data.service';
 import { HttpClient } from '@angular/common/http';
 import { GuestRideResponseDTO } from '../services/models/guest-ride-response-dto';
+import { ChangePricePopup } from '../change-price-popup/change-price-popup';
+import { AdminPopupService } from '../services/admin-popup.service';
 
 
 @Component({
   selector: 'app-main-page',
   standalone: true,
-  imports: [MapViewComponent, RouterOutlet, RideOrdering, FormsModule],
+  imports: [MapViewComponent, RouterOutlet, RideOrdering, FormsModule, ChangePricePopup],
   templateUrl: './main-page.html',
   styleUrls: ['./main-page.css']
 })
 export class MainPageComponent {
-  constructor(public ridePopup: RidePopup, public auth: AuthService, private http: HttpClient, private sharedRideDataService: SharedRideDataService, private cdr: ChangeDetectorRef) {}
+  constructor(public ridePopup: RidePopup, 
+    public auth: AuthService,  
+    private http: HttpClient, 
+    private sharedRideDataService: SharedRideDataService, 
+    private cdr: ChangeDetectorRef,
+    public adminPopup: AdminPopupService) {}
 
   @ViewChild('mapView') mapView!: MapViewComponent;
 
@@ -120,6 +127,7 @@ export class MainPageComponent {
 
   onOverlayClick() {
     this.ridePopup.close();
+    this.adminPopup.close();
   }
 
   // Converts text, example: Novi Sad, into map coordinates [lng, lat] using Mapbox Geocoding API

--- a/frontend/ClickAndDrive/src/app/services/admin-popup.service.ts
+++ b/frontend/ClickAndDrive/src/app/services/admin-popup.service.ts
@@ -1,0 +1,12 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class AdminPopupService {
+  private isOpenSignal = signal(false);
+
+  isOpen() { return this.isOpenSignal(); }
+
+  open() { this.isOpenSignal.set(true); }
+
+  close() { this.isOpenSignal.set(false); }
+}

--- a/frontend/ClickAndDrive/src/app/services/admin.service.ts
+++ b/frontend/ClickAndDrive/src/app/services/admin.service.ts
@@ -2,6 +2,7 @@ import { HttpClient } from "@angular/common/http";
 import { NoteRequest, UserProfileInformation } from "./models/user-profile-information";
 import { Observable } from "rxjs";
 import { Injectable } from "@angular/core";
+import { VehiclePrice } from "./models/vehicle-price";
 
 @Injectable({
     providedIn: 'root'
@@ -36,5 +37,15 @@ export class AdminService {
     leaveNote(userId: number, note: string): Observable<UserProfileInformation> {
         const body: NoteRequest = {message: note}
         return this.http.put<UserProfileInformation>(`${this.apiUrl}/users/${userId}/note`, body);
+    }
+
+    // Get current prices
+    getPrices(): Observable<VehiclePrice> {
+        return this.http.get<VehiclePrice>(`${this.apiUrl}/prices`);
+    }
+
+    // Update prices
+    updatePrices(prices: VehiclePrice): Observable<any> {
+        return this.http.put<any>(`${this.apiUrl}/prices`, prices);
     }
 }

--- a/frontend/ClickAndDrive/src/app/services/models/vehicle-price.ts
+++ b/frontend/ClickAndDrive/src/app/services/models/vehicle-price.ts
@@ -1,0 +1,6 @@
+export interface VehiclePrice {
+    standardBasePrice: number;
+    luxuryBasePrice: number;
+    vanBasePrice: number;
+    pricePerKm: number;
+}


### PR DESCRIPTION
Backend: Add VehiclePriceService interface and VehiclePriceServiceImpl to read/update persistent vehicle pricing (uses VehiclePriceRepository with a single record id=1 and defaults). Update AdminController to use the new service for GET/PUT /prices and inject the repository/service. Add RideRepository.findAllByStatus.

Frontend: Add ChangePricePopup component (TS/HTML/CSS/spec) and VehiclePrice model, plus AdminPopupService to control popup visibility. Integrate the popup into AdminProfile (open on "Change prices") and MainPage (overlay handling, import component). Extend AdminService with getPrices() and updatePrices() to call the backend endpoints. Enables admins to view and update vehicle base prices via the UI.

Closes #154

Trello https://trello.com/c/DIiF7Ukj/117-s2214-defining-ride-pricing-administrator-2