### PR TITLE
Add admin ride monitoring with map view

### DIFF
--- a/frontend/ClickAndDrive/src/app/layout/admin-active-rides/admin-active-rides.css
+++ b/frontend/ClickAndDrive/src/app/layout/admin-active-rides/admin-active-rides.css
@@ -228,3 +228,27 @@
     cursor: pointer;
     font-weight: 600;
 }
+
+.map-container-admin {
+    width: 90vw; /* 90% screen width */
+    max-width: 1200px; 
+    height: 70vh; /* 70% screen height */
+    margin: 20px auto;
+    border-radius: 15px;
+    overflow: hidden;
+    box-shadow: 0 4px 25px rgba(0,0,0,0.5);
+    border: 2px solid #F5CB5C;
+    position: relative;
+}
+
+/* Map is on the whole element */
+app-map-view {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+/* Same as cancel */
+.btn-cancel {
+    margin-bottom: 20px;
+}

--- a/frontend/ClickAndDrive/src/app/layout/admin-active-rides/admin-active-rides.html
+++ b/frontend/ClickAndDrive/src/app/layout/admin-active-rides/admin-active-rides.html
@@ -1,24 +1,36 @@
 <div class="scheduled-rides">
   <div class="content-wrapper">
     <div class="header-section">
-      <h1 class="scheduled-rides-title">Choose drive to follow (admin)</h1>
+      <h1 class="scheduled-rides-title">
+        {{ isMonitoring ? 'Monitoring Ride #' + selectedRide?.rideId : 'Choose drive to follow (admin)' }}
+      </h1>
+      <button *ngIf="isMonitoring" class="btn-cancel" (click)="backToTable()" style="margin-bottom: 12px;">
+        Back to List
+      </button>
     </div>
 
-    <div class="table-container">
+    <!-- TABELA (vidi se samo kad NIJE monitoring) -->
+    <div class="table-container" *ngIf="!isMonitoring">
       <table class="figma-table">
         <thead>
           <tr>
             <th>Origin</th>
+            <th></th>
             <th>Destination</th>
+            <th></th>
             <th>Driver</th>
+            <th></th>
             <th>Follow</th>
           </tr>
         </thead>
         <tbody>
           <tr *ngFor="let ride of activeRides">
             <td>{{ ride.originAddress }}</td>
+            <td></td>
             <td>{{ ride.destinationAddress }}</td>
+            <td></td>
             <td>{{ ride.driverEmail }}</td>
+            <td></td>
             <td>
               <button class="btn-follow" (click)="followRide(ride)">Follow</button>
             </td>
@@ -26,5 +38,10 @@
         </tbody>
       </table>
     </div>
+
+    <div class="map-container-admin" *ngIf="isMonitoring">
+    <app-map-view></app-map-view>
+    </div>
+
   </div>
 </div>

--- a/frontend/ClickAndDrive/src/app/layout/admin-active-rides/admin-active-rides.ts
+++ b/frontend/ClickAndDrive/src/app/layout/admin-active-rides/admin-active-rides.ts
@@ -1,37 +1,70 @@
-import { Component, OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common'; // OBAVEZNO ZA ngFor
-import { RideOrderingService} from '../../services/ride.service';
-import { Router } from '@angular/router';
+import { ChangeDetectorRef, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RideOrderingService } from '../../services/ride.service';
 import { AdminRideStateDTO } from '../../services/models/admin-ride-state';
+import { MapViewComponent } from '../../components/map-view/map-view'; 
+import { Map } from '../../services/map'; 
 
 @Component({
   selector: 'app-admin-active-rides',
   standalone: true, 
-  imports: [CommonModule], 
+  imports: [CommonModule, MapViewComponent], 
   templateUrl: './admin-active-rides.html',
   styleUrls: ['./admin-active-rides.css']
 })
 export class AdminActiveRides implements OnInit {
   activeRides: AdminRideStateDTO[] = [];
+  
+  // Kontrola prikaza
+  isMonitoring = false;
+  selectedRide: AdminRideStateDTO | null = null;
+  cdr = inject(ChangeDetectorRef);
 
-  constructor(
-    private rideService: RideOrderingService, 
-    private router: Router
-  ) {}
+  @ViewChild(MapViewComponent) mapView!: MapViewComponent;
+
+  private mapService = inject(Map);
+  private rideService = inject(RideOrderingService);
 
   ngOnInit() {
+    this.loadActiveRides();
+  }
+
+  loadActiveRides() {
     this.rideService.getActiveRides().subscribe({
       next: (res) => {
         this.activeRides = res;
+        this.cdr.detectChanges();
       },
-      error: (err) => {
-        console.error('403 ili druga greška:', err);
-        // Ako je 403, proveri da li je ruta /api/admin/** dozvoljena za ADMIN rolu u Springu
-      }
+      error: (err) => console.error('Greška pri učitavanju vožnji:', err)
     });
   }
 
-  followRide(ride: AdminRideStateDTO) {
-    this.router.navigate(['/main-page'], { queryParams: { monitorRideId: ride.rideId } });
+  async followRide(ride: AdminRideStateDTO) {
+    this.selectedRide = ride;
+    this.isMonitoring = true;
+
+    
+    setTimeout(async () => {
+      if (this.mapView && ride.originAddress && ride.destinationAddress) {
+        try {
+          
+          const originCoords = await this.mapService.geocodeAddress(ride.originAddress);
+          const destCoords = await this.mapService.geocodeAddress(ride.destinationAddress);
+
+          if (originCoords && destCoords) {
+            //simulate tracking
+            this.mapView.drawRouteWithStops([originCoords, destCoords], true);
+          }
+        } catch (err) {
+          console.error('Greška u geokodiranju:', err);
+        }
+      }
+    }, 200);
+  }
+
+  backToTable() {
+    this.isMonitoring = false;
+    this.selectedRide = null;
+    this.loadActiveRides();
   }
 }


### PR DESCRIPTION
Toggle admin active-rides between a table and an interactive map. Adds MapViewComponent and Map service usage to geocode origin/destination, draw route and start simulation when following a ride. Implements isMonitoring/selectedRide state, followRide/backToTable handlers, and loadActiveRides with explicit change detection. Adds CSS for .map-container-admin and small HTML adjustments (Back button, conditional table/map rendering, extra table cells for spacing). Includes ViewChild, injected services, and minor error logging.

Closes #179 

Trello https://trello.com/c/qn6CIgZR/126-s2213-admin-active-ride-simulation