### PR TITLE
Implement active vehicle markers on mobile home map

### DIFF
--- a/backend/src/main/java/com/example/demo/services/VehicleServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/services/VehicleServiceImpl.java
@@ -23,14 +23,17 @@ public class VehicleServiceImpl implements VehicleService {
     public List<ActiveVehicleResponseDTO> getAllActiveVehicles() {
         List<Vehicle> vehicles = vehicleRepository.findAll();
 
-        return vehicles.stream().map(v -> new ActiveVehicleResponseDTO(
-                v.getId(),
-                new LocationDTO(
-                        v.getLocation().getLatitude(),
-                        v.getLocation().getLongitude(),
-                        v.getLocation().getAddress()
-                ),
-                v.getBusy()
-        )).collect(Collectors.toList());
+        return vehicles.stream()
+                .filter(v -> v.getLocation() != null)
+                .map(v -> new ActiveVehicleResponseDTO(
+                        v.getId(),
+                        new LocationDTO(
+                                v.getLocation().getLatitude(),
+                                v.getLocation().getLongitude(),
+                                v.getLocation().getAddress()
+                        ),
+                        Boolean.TRUE.equals(v.getBusy())
+                ))
+                .collect(Collectors.toList());
     }
 }

--- a/mobile-version/Navbar-shortened/app/src/main/java/com/example/clickanddrive/HomeFragment.java
+++ b/mobile-version/Navbar-shortened/app/src/main/java/com/example/clickanddrive/HomeFragment.java
@@ -1,6 +1,12 @@
 package com.example.clickanddrive;
 
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -10,10 +16,12 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 
 import com.example.clickanddrive.clients.ClientUtils;
 import com.example.clickanddrive.dtosample.LocationDTO;
+import com.example.clickanddrive.dtosample.responses.ActiveVehicleResponse;
 import com.example.clickanddrive.map.MapHelper;
 import com.example.clickanddrive.map.MapboxDirections;
 import com.example.clickanddrive.map.MapboxGeocoder;
@@ -22,6 +30,12 @@ import com.mapbox.geojson.Point;
 import com.mapbox.maps.CameraOptions;
 import com.mapbox.maps.MapView;
 import com.mapbox.maps.Style;
+import com.mapbox.maps.plugin.annotation.AnnotationConfig;
+import com.mapbox.maps.plugin.annotation.AnnotationPlugin;
+import com.mapbox.maps.plugin.annotation.AnnotationPluginImplKt;
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager;
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManagerKt;
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +46,25 @@ import retrofit2.Response;
 
 public class HomeFragment extends Fragment {
 
+    private static final String TAG = "HomeFragment";
+
+    private static final long VEHICLE_REFRESH_INTERVAL_MS = 10_000L;
+
     private MapView mapView;
+
+    private PointAnnotationManager vehicleMarkerManager;
+    private Bitmap availableVehicleIcon;
+    private Bitmap busyVehicleIcon;
+
+    private final Handler vehicleRefreshHandler = new Handler(Looper.getMainLooper());
+
+    private final Runnable vehicleRefreshRunnable = new Runnable() {
+        @Override
+        public void run() {
+            loadActiveVehicles();
+            vehicleRefreshHandler.postDelayed(this, VEHICLE_REFRESH_INTERVAL_MS);
+        }
+    };
 
     private View guestRidePanel;
     private TextView tvEtaValue;
@@ -65,7 +97,12 @@ public class HomeFragment extends Fragment {
 
         mapView.getMapboxMap().setCamera(cameraOptions);
 
-        mapView.getMapboxMap().loadStyleUri(Style.DARK, style -> checkAndDrawIncomingRoute());
+        mapView.getMapboxMap().loadStyleUri(Style.DARK, style -> {
+            initializeVehicleMarkerManager();
+            checkAndDrawIncomingRoute();
+            loadActiveVehicles();
+            startVehicleRefresh();
+        });
 
         btnCancelGuestRide.setOnClickListener(v -> cancelGuestRide());
 
@@ -172,19 +209,28 @@ public class HomeFragment extends Fragment {
                 if (!isAdded()) return;
 
                 requireActivity().runOnUiThread(() ->
-                        Toast.makeText(getContext(),
+                        Toast.makeText(
+                                getContext(),
                                 "Geocoding failed for: " + address,
-                                Toast.LENGTH_SHORT).show());
+                                Toast.LENGTH_SHORT
+                        ).show()
+                );
             }
         });
     }
 
-    private void requestDirections(List<String> addresses, List<MapboxDirections.Coordinate> waypoints) {
+    private void requestDirections(List<String> addresses,
+                                   List<MapboxDirections.Coordinate> waypoints) {
         if (waypoints.size() < 2) {
             if (!isAdded()) return;
 
             requireActivity().runOnUiThread(() ->
-                    Toast.makeText(getContext(), "Unable to calculate route", Toast.LENGTH_SHORT).show());
+                    Toast.makeText(
+                            getContext(),
+                            "Unable to calculate route",
+                            Toast.LENGTH_SHORT
+                    ).show()
+            );
             return;
         }
 
@@ -199,6 +245,7 @@ public class HomeFragment extends Fragment {
 
                     if (routeData.getDurationMinutes() <= 0) {
                         routeData.setDurationMinutes(result.durationMinutes);
+
                         if (isGuestRide) {
                             tvEtaValue.setText(result.durationMinutes + " min");
                         }
@@ -211,6 +258,7 @@ public class HomeFragment extends Fragment {
                     routeData.setDestinationLat(waypoints.get(waypoints.size() - 1).lat);
 
                     List<LocationDTO> stopLocations = new ArrayList<>();
+
                     if (waypoints.size() > 2) {
                         for (int i = 1; i < waypoints.size() - 1; i++) {
                             stopLocations.add(new LocationDTO(
@@ -220,6 +268,7 @@ public class HomeFragment extends Fragment {
                             ));
                         }
                     }
+
                     routeData.setStopLocations(stopLocations);
 
                     MapHelper mapHelper = new MapHelper(mapView);
@@ -239,11 +288,107 @@ public class HomeFragment extends Fragment {
                 if (!isAdded()) return;
 
                 requireActivity().runOnUiThread(() ->
-                        Toast.makeText(getContext(),
+                        Toast.makeText(
+                                getContext(),
                                 "Failed to draw route",
-                                Toast.LENGTH_SHORT).show());
+                                Toast.LENGTH_SHORT
+                        ).show()
+                );
             }
         });
+    }
+
+    private void initializeVehicleMarkerManager() {
+        AnnotationPlugin annotationPlugin = AnnotationPluginImplKt.getAnnotations(mapView);
+
+        vehicleMarkerManager = PointAnnotationManagerKt.createPointAnnotationManager(
+                annotationPlugin,
+                new AnnotationConfig()
+        );
+
+        availableVehicleIcon = bitmapFromVector(R.drawable.ic_vehicle_available);
+        busyVehicleIcon = bitmapFromVector(R.drawable.ic_vehicle_busy);
+    }
+
+    private Bitmap bitmapFromVector(int drawableId) {
+        Drawable drawable = ContextCompat.getDrawable(requireContext(), drawableId);
+
+        if (drawable == null) {
+            return null;
+        }
+
+        Bitmap bitmap = Bitmap.createBitmap(
+                drawable.getIntrinsicWidth(),
+                drawable.getIntrinsicHeight(),
+                Bitmap.Config.ARGB_8888
+        );
+
+        Canvas canvas = new Canvas(bitmap);
+        drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+        drawable.draw(canvas);
+
+        return bitmap;
+    }
+
+    private void startVehicleRefresh() {
+        vehicleRefreshHandler.removeCallbacks(vehicleRefreshRunnable);
+        vehicleRefreshHandler.postDelayed(vehicleRefreshRunnable, VEHICLE_REFRESH_INTERVAL_MS);
+    }
+
+    private void loadActiveVehicles() {
+        ClientUtils.vehicleService.getActiveVehicles().enqueue(new Callback<List<ActiveVehicleResponse>>() {
+            @Override
+            public void onResponse(Call<List<ActiveVehicleResponse>> call,
+                                   Response<List<ActiveVehicleResponse>> response) {
+                if (!isAdded()) return;
+
+                if (response.isSuccessful() && response.body() != null) {
+                    drawVehicleMarkers(response.body());
+                } else {
+                    Log.e(TAG, "Failed to load active vehicles. Code: " + response.code());
+                }
+            }
+
+            @Override
+            public void onFailure(Call<List<ActiveVehicleResponse>> call, Throwable t) {
+                if (!isAdded()) return;
+
+                Log.e(TAG, "Network error while loading active vehicles", t);
+            }
+        });
+    }
+
+    private void drawVehicleMarkers(List<ActiveVehicleResponse> vehicles) {
+        if (vehicleMarkerManager == null || vehicles == null) return;
+
+        vehicleMarkerManager.deleteAll();
+
+        for (ActiveVehicleResponse vehicle : vehicles) {
+            if (vehicle == null || vehicle.getCurrentLocation() == null) continue;
+
+            LocationDTO location = vehicle.getCurrentLocation();
+
+            /*
+             * Backend currently returns swapped coordinates in LocationDTO.
+             * Web frontend already compensates for this by using latitude as longitude.
+             * Keep the same logic here until backend/frontend coordinate contract is fixed globally.
+             */
+            double longitude = location.getLatitude();
+            double latitude = location.getLongitude();
+
+            if (longitude == 0.0 && latitude == 0.0) continue;
+
+            Bitmap vehicleIcon = vehicle.isBusy() ? busyVehicleIcon : availableVehicleIcon;
+
+            if (vehicleIcon == null) continue;
+
+            PointAnnotationOptions markerOptions = new PointAnnotationOptions()
+                    .withPoint(Point.fromLngLat(longitude, latitude))
+                    .withIconImage(vehicleIcon)
+                    .withIconSize(0.7);
+
+            vehicleMarkerManager.create(markerOptions);
+        }
     }
 
     private void cancelGuestRide() {
@@ -286,24 +431,45 @@ public class HomeFragment extends Fragment {
     @Override
     public void onStart() {
         super.onStart();
-        if (mapView != null) mapView.onStart();
+
+        if (mapView != null) {
+            mapView.onStart();
+        }
     }
 
     @Override
     public void onStop() {
         super.onStop();
-        if (mapView != null) mapView.onStop();
+
+        vehicleRefreshHandler.removeCallbacks(vehicleRefreshRunnable);
+
+        if (mapView != null) {
+            mapView.onStop();
+        }
     }
 
     @Override
     public void onLowMemory() {
         super.onLowMemory();
-        if (mapView != null) mapView.onLowMemory();
+
+        if (mapView != null) {
+            mapView.onLowMemory();
+        }
     }
 
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        if (mapView != null) mapView.onDestroy();
+
+        vehicleRefreshHandler.removeCallbacks(vehicleRefreshRunnable);
+
+        if (vehicleMarkerManager != null) {
+            vehicleMarkerManager.deleteAll();
+            vehicleMarkerManager = null;
+        }
+
+        if (mapView != null) {
+            mapView.onDestroy();
+        }
     }
 }

--- a/mobile-version/Navbar-shortened/app/src/main/java/com/example/clickanddrive/clients/ClientUtils.java
+++ b/mobile-version/Navbar-shortened/app/src/main/java/com/example/clickanddrive/clients/ClientUtils.java
@@ -9,6 +9,7 @@ import com.example.clickanddrive.clients.services.PassengerService;
 import com.example.clickanddrive.clients.services.RideService;
 import com.example.clickanddrive.clients.services.UserService;
 import com.example.clickanddrive.clients.services.GuestRideService;
+import com.example.clickanddrive.clients.services.VehicleService;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonPrimitive;
@@ -77,4 +78,6 @@ public class ClientUtils {
     public static AdminService adminService = retrofit.create(AdminService.class);
     public static PassengerService passengerService = retrofit.create(PassengerService.class);
     public static PanicService panicService = retrofit.create(PanicService.class);
+
+    public static VehicleService vehicleService = retrofit.create(VehicleService.class);
 }

--- a/mobile-version/Navbar-shortened/app/src/main/java/com/example/clickanddrive/clients/services/VehicleService.java
+++ b/mobile-version/Navbar-shortened/app/src/main/java/com/example/clickanddrive/clients/services/VehicleService.java
@@ -1,0 +1,14 @@
+package com.example.clickanddrive.clients.services;
+
+import com.example.clickanddrive.dtosample.responses.ActiveVehicleResponse;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+
+public interface VehicleService {
+
+    @GET("vehicles/active")
+    Call<List<ActiveVehicleResponse>> getActiveVehicles();
+}

--- a/mobile-version/Navbar-shortened/app/src/main/java/com/example/clickanddrive/dtosample/responses/ActiveVehicleResponse.java
+++ b/mobile-version/Navbar-shortened/app/src/main/java/com/example/clickanddrive/dtosample/responses/ActiveVehicleResponse.java
@@ -1,0 +1,42 @@
+package com.example.clickanddrive.dtosample.responses;
+
+import com.example.clickanddrive.dtosample.LocationDTO;
+
+public class ActiveVehicleResponse {
+    private Long id;
+    private LocationDTO currentLocation;
+    private boolean busy;
+
+    public ActiveVehicleResponse() {
+    }
+
+    public ActiveVehicleResponse(Long id, LocationDTO currentLocation, boolean busy) {
+        this.id = id;
+        this.currentLocation = currentLocation;
+        this.busy = busy;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public LocationDTO getCurrentLocation() {
+        return currentLocation;
+    }
+
+    public void setCurrentLocation(LocationDTO currentLocation) {
+        this.currentLocation = currentLocation;
+    }
+
+    public boolean isBusy() {
+        return busy;
+    }
+
+    public void setBusy(boolean busy) {
+        this.busy = busy;
+    }
+}

--- a/mobile-version/Navbar-shortened/app/src/main/res/drawable/ic_vehicle_available.xml
+++ b/mobile-version/Navbar-shortened/app/src/main/res/drawable/ic_vehicle_available.xml
@@ -1,0 +1,62 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="34dp"
+    android:height="32dp"
+    android:viewportWidth="34"
+    android:viewportHeight="32">
+
+    <path
+        android:strokeWidth="1.2"
+        android:pathData="M5,26.259H29"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+
+    <path
+        android:strokeWidth="1.2"
+        android:pathData="M8,26.259V29.479C8,30.365 7.325,31.089 6.5,31.089H3.5C2.675,31.089 2,30.365 2,29.479V18.499C2,17.243 2.27,16.02 2.795,14.893L6.35,7.278C7.37,5.088 9.44,3.72 11.72,3.72H22.31C24.59,3.72 26.66,5.104 27.68,7.278L31.235,14.893C31.76,16.004 32.03,17.243 32.03,18.499V29.479C32.03,30.365 31.355,31.089 30.53,31.089H27.53C26.705,31.089 26.03,30.365 26.03,29.479V26.259"
+        android:strokeLineJoin="round"
+        android:fillColor="#F5CB5C"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+
+    <path
+        android:strokeWidth="1.2"
+        android:pathData="M33.5,13.396H29.75C29.75,13.396 24.5,14.99 17,14.99C9.5,14.99 4.25,13.396 4.25,13.396H0.5"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+
+    <path
+        android:strokeWidth="1.2"
+        android:pathData="M27.5,18.209C27.5,19.095 26.825,19.819 26,19.819H23"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+
+    <path
+        android:strokeWidth="1.2"
+        android:pathData="M6.5,18.209C6.5,19.095 7.175,19.819 8,19.819H11"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+
+    <path
+        android:strokeWidth="1.2"
+        android:pathData="M14,23.039H20"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+
+    <path
+        android:strokeWidth="1.2"
+        android:pathData="M12.5,3.72L13.58,1.385C13.835,0.838 14.36,0.5 14.915,0.5H19.055C19.625,0.5 20.15,0.838 20.39,1.385L21.47,3.72"
+        android:strokeLineJoin="round"
+        android:fillColor="#F5CB5C"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+</vector>

--- a/mobile-version/Navbar-shortened/app/src/main/res/drawable/ic_vehicle_busy.xml
+++ b/mobile-version/Navbar-shortened/app/src/main/res/drawable/ic_vehicle_busy.xml
@@ -1,0 +1,62 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="34dp"
+    android:height="32dp"
+    android:viewportWidth="34"
+    android:viewportHeight="32">
+
+    <path
+        android:strokeWidth="1.2"
+        android:pathData="M5,26.259H29"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+
+    <path
+        android:strokeWidth="1.2"
+        android:pathData="M8,26.259V29.479C8,30.365 7.325,31.089 6.5,31.089H3.5C2.675,31.089 2,30.365 2,29.479V18.499C2,17.243 2.27,16.02 2.795,14.893L6.35,7.278C7.37,5.088 9.44,3.72 11.72,3.72H22.31C24.59,3.72 26.66,5.104 27.68,7.278L31.235,14.893C31.76,16.004 32.03,17.243 32.03,18.499V29.479C32.03,30.365 31.355,31.089 30.53,31.089H27.53C26.705,31.089 26.03,30.365 26.03,29.479V26.259"
+        android:strokeLineJoin="round"
+        android:fillColor="#D50000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+
+    <path
+        android:strokeWidth="1.2"
+        android:pathData="M33.5,13.396H29.75C29.75,13.396 24.5,14.99 17,14.99C9.5,14.99 4.25,13.396 4.25,13.396H0.5"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+
+    <path
+        android:strokeWidth="1.2"
+        android:pathData="M27.5,18.209C27.5,19.095 26.825,19.819 26,19.819H23"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+
+    <path
+        android:strokeWidth="1.2"
+        android:pathData="M6.5,18.209C6.5,19.095 7.175,19.819 8,19.819H11"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+
+    <path
+        android:strokeWidth="1.2"
+        android:pathData="M14,23.039H20"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+
+    <path
+        android:strokeWidth="1.2"
+        android:pathData="M12.5,3.72L13.58,1.385C13.835,0.838 14.36,0.5 14.915,0.5H19.055C19.625,0.5 20.15,0.838 20.39,1.385L21.47,3.72"
+        android:strokeLineJoin="round"
+        android:fillColor="#D50000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
## Summary

This PR implements the initial mobile support for displaying active vehicles on the home map.

The mobile app now loads active vehicles from the backend and displays them as vehicle markers on the Mapbox map. Vehicle availability is visually represented with different marker colors:

- Yellow vehicle icon for available vehicles
- Red vehicle icon for busy vehicles

This covers the initial part of the Student 2 requirement related to displaying currently active vehicles on the map.

## Changes

### Backend

- Verified and reused the existing endpoint for active vehicles:
  - `GET /api/vehicles/active`
- Active vehicles are loaded from the database through the existing vehicle service logic.
- The existing latitude/longitude mapping behavior was kept unchanged to avoid breaking the current web frontend map implementation.

### Mobile

- Added `ActiveVehicleResponse` DTO for parsing active vehicle data from the backend.
- Added `VehicleService` Retrofit interface with `getActiveVehicles()`.
- Registered `VehicleService` in `ClientUtils`.
- Updated `HomeFragment` to:
  - call the backend endpoint for active vehicles,
  - draw vehicle markers on the Mapbox map,
  - refresh vehicle positions periodically,
  - display available vehicles with a yellow icon,
  - display busy vehicles with a red icon.
- Added vector drawable icons for available and busy vehicles.

## Notes

The backend currently returns vehicle coordinates in a format already expected by the existing web frontend. Because of that, the mobile implementation follows the same coordinate handling logic to avoid breaking compatibility.

Closes #197 